### PR TITLE
Pkg 4728 gunicorn 21.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "22.0.0" %}
+{% set version = "21.2.0" %}
 
 package:
   name: gunicorn
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/g/gunicorn/gunicorn-{{ version }}.tar.gz
-  sha256: 4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63
+  sha256: 88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033
 
 build:
   skip: True  # [win]
-  skip: True  # [py<38]
+  skip: True  # [py<35]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   preserve_egg_dir: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,16 +43,14 @@ test:
     # - pastedeploy
 
 about:
-  home: http://gunicorn.org
+  home: https://gunicorn.org
   license: MIT
+  license_family: MIT
   license_file: LICENSE
-  summary: 'WSGI HTTP Server for UNIX'
+  summary: WSGI HTTP Server for UNIX
   description: |
-    Gunicorn pre-fork worker model ported from Ruby's Unicorn project.Gunicorn
-    server is broadly compatible with various web frameworks,simply
-    implemented,light on server resources and fairly speedy.
-  doc_url: http://docs.gunicorn.org/en/stable/
-  doc_source_url: https://github.com/benoitc/gunicorn/blob/master/docs/source/index.rst
+    Gunicorn pre-fork worker model ported from Ruby's Unicorn project. Gunicorn server is broadly compatible with various web frameworks,simply implemented,light on server resources and fairly speedy.
+  doc_url: https://docs.gunicorn.org
   dev_url: https://github.com/benoitc/gunicorn
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,11 @@ requirements:
   run:
     - python
     - packaging
+    - importlib-metadata. # [py<38]
+  run_constrained:
+    - gevent >=1.4.0
+    - eventlet >=0.24.1
+    - tornado >=0.2
 
 test:
   imports:
@@ -40,7 +45,6 @@ test:
     - pip check
   requires:
     - pip
-    - paste # [py<312]
 
 about:
   home: https://gunicorn.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,7 @@ test:
     - pip check
   requires:
     - pip
-    - paste # [py<312]
-    - pastedeploy # [py<312]
+    - paste # [py<312 or s390x]
 
 about:
   home: https://gunicorn.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,8 @@ source:
   sha256: 88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033
 
 build:
-  skip: True  # [win]
+  # Failing on s390x and also not needed on s390x for mlflow
+  skip: True  # [win or s390x]
   skip: True  # [py<35]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
@@ -39,7 +40,7 @@ test:
     - pip check
   requires:
     - pip
-    - paste # [py<312 or s390x]
+    - paste # [py<312]
 
 about:
   home: https://gunicorn.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   skip: True  # [win]
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   preserve_egg_dir: True
@@ -39,8 +39,8 @@ test:
     - pip check
   requires:
     - pip
-    # - paste
-    # - pastedeploy
+    - paste # [py<312]
+    - pastedeploy # [py<312]
 
 about:
   home: https://gunicorn.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20.1.0" %}
+{% set version = "22.0.0" %}
 
 package:
   name: gunicorn
@@ -6,13 +6,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/g/gunicorn/gunicorn-{{ version }}.tar.gz
-  sha256: e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
+  sha256: 4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63
 
 build:
   skip: True  # [win]
-  skip: True  # [py<30]
+  skip: True  # [py<37]
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   preserve_egg_dir: True
   entry_points:
     - gunicorn=gunicorn.app.wsgiapp:run
@@ -21,9 +21,11 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
-    - setuptools
+    - packaging
 
 test:
   imports:
@@ -34,9 +36,11 @@ test:
     - gunicorn.workers
   commands:
     - gunicorn --help
+    - pip check
   requires:
-    - paste
-    - pastedeploy
+    - pip
+    # - paste
+    # - pastedeploy
 
 about:
   home: http://gunicorn.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
   run:
     - python
     - packaging
-    - importlib-metadata. # [py<38]
+    - importlib-metadata # [py<38]
   run_constrained:
     - gevent >=1.4.0
     - eventlet >=0.24.1


### PR DESCRIPTION
gunicorn 21.2.0

**Destination channel:** {defaults}

### Links

- [PKG-4728](https://anaconda.atlassian.net/browse/PKG-4728) 
- [Upstream repository](https://github.com/benoitc/gunicorn/tree/21.2.0)
- [Upstream changelog/diff](https://github.com/benoitc/gunicorn/compare/20.1.0...21.2.0)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/graphql-relay-feedstock/pull/2 > https://github.com/AnacondaRecipes/graphene-feedstock/pull/2 > https://github.com/AnacondaRecipes/mlflow-feedstock/pull/6

### Explanation of changes:

- Although the latest available upstream is `22.0.0`, `gunicorn <22` is needed for `mlflow`, so intentionally updating to version `21.2.0`


[PKG-4728]: https://anaconda.atlassian.net/browse/PKG-4728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ