### PR TITLE
gunicorn 22.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.2.0" %}
+{% set version = "22.0.0" %}
 
 package:
   name: gunicorn
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/g/gunicorn/gunicorn-{{ version }}.tar.gz
-  sha256: 88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033
+  sha256: 4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63
 
 build:
   # Failing on s390x and also not needed on s390x for mlflow
   skip: True  # [win or s390x]
-  skip: True  # [py<35]
+  skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   preserve_egg_dir: True
@@ -30,7 +30,7 @@ requirements:
     - importlib-metadata # [py<38]
   run_constrained:
     - gevent >=1.4.0
-    - eventlet >=0.24.1
+    - eventlet >=0.24.1,!=0.36.0
     - tornado >=0.2
 
 test:
@@ -40,11 +40,11 @@ test:
     - gunicorn.http
     - gunicorn.instrument
     - gunicorn.workers
+  requires:
+    - pip
   commands:
     - gunicorn --help
     - pip check
-  requires:
-    - pip
 
 about:
   home: https://gunicorn.org


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5141](https://anaconda.atlassian.net/browse/PKG-5141)
- release-notes: https://github.com/benoitc/gunicorn/releases
- release-notes-tagged: https://github.com/benoitc/gunicorn/releases/tag/22.0.0
- release-diff: https://github.com/benoitc/gunicorn/compare/21.2.0...22.0.0
- license: https://github.com/benoitc/gunicorn/blob/master/LICENSE
- requirements-tagged:
  - https://github.com/benoitc/gunicorn/blob/22.0.0/pyproject.toml



### Explanation of changes:

- Skip py<37

### Notes:

- Updating because the CVE-2024-1135 has been fixed in v22.0.0


[PKG-5141]: https://anaconda.atlassian.net/browse/PKG-5141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ